### PR TITLE
Adds JELLYFIN_USER_ID to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - TZ=America/New_York
       - JELLYFIN_SERVER_URL=https://www.jellyfin.example.com
       - JELLYFIN_API_KEY=1a1111aa1a1a1aaaa11a11aa111aaa11
+      - JELLYFIN_USER_ID=2b2222bb2b2b2bbbb22b22bb222bbb22
     volumes:
       - ${CONFIG_DIR}/jellyfin-auto-collections/config:/app/config
     restart: unless-stopped


### PR DESCRIPTION
Perhaps this saves someone else a couple of time units trying to figure out why you keep getting invalid api key when you forgot to set JELLYFIN_USER_ID to your user id :-)